### PR TITLE
Fix issues with multiple mock datas over multiple functtions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "jazim-test-package",
-  "version": "1.0.7",
+  "name": "mock-typeorm",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "jazim-test-package",
-      "version": "1.0.7",
+      "name": "mock-typeorm",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^11.1.6",

--- a/src/mock-typeorm.ts
+++ b/src/mock-typeorm.ts
@@ -61,12 +61,15 @@ export class MockTypeORM {
           const totalMockItemsFoundInMethod = Object.keys(mockMethod).length;
           mockMethod[totalMockItemsFoundInMethod] = mockData;
         } else {
-          self.mocks[repositoryName] = { [method]: { 0: mockData } };
+          //self.mocks[repositoryName] = { [method]: { 0: mockData } };
+          self.mocks[repositoryName][method] = { 0: mockData };
 
           // initialize mock history with empty state
           if (!self.mockHistory[repositoryName]) {
             self.mockHistory = { ...self.mockHistory, [repositoryName]: {} };
           }
+
+          // is this the same issue as above, overwriting the existing history when a new method is passed?
           self.mockHistory[repositoryName] = { [method]: 0 };
         }
 

--- a/src/mock-typeorm.ts
+++ b/src/mock-typeorm.ts
@@ -61,7 +61,6 @@ export class MockTypeORM {
           const totalMockItemsFoundInMethod = Object.keys(mockMethod).length;
           mockMethod[totalMockItemsFoundInMethod] = mockData;
         } else {
-          //self.mocks[repositoryName] = { [method]: { 0: mockData } };
           self.mocks[repositoryName][method] = { 0: mockData };
 
           // initialize mock history with empty state
@@ -69,8 +68,7 @@ export class MockTypeORM {
             self.mockHistory = { ...self.mockHistory, [repositoryName]: {} };
           }
 
-          // is this the same issue as above, overwriting the existing history when a new method is passed?
-          self.mockHistory[repositoryName] = { [method]: 0 };
+          self.mockHistory[repositoryName][method] = 0;
         }
 
         return this;


### PR DESCRIPTION
Fixes an issue where trying to mock different functions on the same repo, overwrites the previously set mock data for other functions.

See issue #1 for more details