### PR TITLE
Passing values and propagate exceptions in `transaction()`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mock-typeorm",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mock-typeorm",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^11.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-typeorm",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Never hit the database again while testing",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/mock-typeorm.ts
+++ b/src/mock-typeorm.ts
@@ -264,9 +264,9 @@ export class MockTypeORM {
         const manager = this.connection.manager;
 
         if (typeof isolationLevelOrCallback === "string") {
-          callback(manager);
+          return callback(manager);
         } else {
-          isolationLevelOrCallback(manager);
+          return isolationLevelOrCallback(manager);
         }
       });
     }

--- a/tests/dataSource.test.ts
+++ b/tests/dataSource.test.ts
@@ -84,6 +84,28 @@ describe("DataSource", () => {
       expect(roles).toEqual(mockRoles);
     });
 
+    it("should pass the returned value of an transaction", async () => {
+      const mockRoles = ["role"];
+      const typeorm = new MockTypeORM();
+      typeorm.onMock(Role).toReturn(mockRoles, "find");
+
+      const roles= await dataSource.transaction(async (manager) => {
+        return await manager.find(Role, {});
+      });
+
+      expect(roles).toEqual(mockRoles);
+    });
+
+    it("should propagate exceptions", async () => {
+      new MockTypeORM();
+
+      const promise= dataSource.transaction(async (manager) => {
+        throw Error("bad")
+      });
+
+      await expect(promise).rejects.toThrow("bad")
+    });
+
     it("should run method inside transaction with isolation level passed in", async () => {
       const mockRoles = ["role1"];
       const typeorm = new MockTypeORM();
@@ -95,6 +117,28 @@ describe("DataSource", () => {
       });
 
       expect(roles).toEqual(mockRoles);
+    });
+
+    it("should run method inside transaction with isolation level passed in and pass the value", async () => {
+      const mockRoles = ["role1"];
+      const typeorm = new MockTypeORM();
+      typeorm.onMock(Role).toReturn(mockRoles, "find");
+
+      const roles = await dataSource.manager.transaction("READ COMMITTED", async (manager) => {
+        return await manager.find(Role, {});
+      });
+
+      expect(roles).toEqual(mockRoles);
+    });
+
+    it("should propagate exception inside transaction with isolation level", async () => {
+      new MockTypeORM();
+
+      const promise = dataSource.manager.transaction("READ COMMITTED", async () => {
+        throw new Error("very bad");
+      });
+
+      await expect(promise).rejects.toThrow("very bad");
     });
 
     describe("callback", () => {


### PR DESCRIPTION
Currently the mocked `transaction()` method does not return the value of the callbacks. This cause the value returned by the callback to not get passed and any exception is not handled. This pull requests fixes this.

Example which failed to be tested before:

```typescript
class Service {
    constructor(private em: EntityManager){}

    async create(from: CreateExampleDto): Promise<string> {
        return await this.em.transaction(async (em) => {
            const result = await em.insert(Example, from);
            return result.identifiers[0].id;
        });
    }
}
```


Related: https://github.com/jazimabbas/mock-typeorm/issues/5