### PR TITLE
Add "merge" to repositoryMethods

### DIFF
--- a/src/constants/repository.ts
+++ b/src/constants/repository.ts
@@ -25,6 +25,7 @@ export const repositoryMethods: RepositoryMethods[] = [
   "increment",
   "insert",
   "maximum",
+  "merge",
   "minimum",
   "preload",
   "query",


### PR DESCRIPTION
I make use of the ['merge' repository function](https://typeorm.io/repository-api) and when adding this package to mock typeorm and add some tests encountered this error:

```
test at tests/library/device.test.ts:1:2278
✖ should update the device (0.27075ms)
  Error [EntityMetadataNotFoundError]: No metadata for "Device" was found.
      at DataSource.getMetadata (project/node_modules/typeorm/data-source/src/data-source/DataSource.ts:450:30)
      at Repository.get metadata (project/node_modules/typeorm/repository/src/repository/Repository.ts:53:40)
      at Repository.merge (project/node_modules/typeorm/repository/src/repository/Repository.ts:143:18)
      at Module.updateDevice (project/src/libraries/device.ts:32:14)
      at async TestContext.<anonymous> (project/tests/library/device.test.ts:145:22)
      at async Test.run (node:internal/test_runner/test:935:9)
      at async Promise.all (index 0)
      at async Suite.run (node:internal/test_runner/test:1320:7)
      at async Suite.processPendingSubtests (node:internal/test_runner/test:633:7)
 ```
 
 Ultimately adding the "merge" function to the list made my error go away and my tests do seem to work correctly. Hopefully this is all that needs to be done?