### PR TITLE
🐛 fix: align create() mock with TypeORM's synchronous behavior

### DIFF
--- a/src/helpers/general.ts
+++ b/src/helpers/general.ts
@@ -19,6 +19,6 @@ export function createClass(name: string) {
 
 type Obj = { [x: string]: any };
 
-export function getDefinedMethods(object: Obj, methods: string[]) {
+export function retrieveAvailableMethods(object: Obj, methods: string[]) {
   return methods.filter((method) => !!object[method]);
 }

--- a/tests/general.test.ts
+++ b/tests/general.test.ts
@@ -2,7 +2,7 @@ import { SinonStub } from "sinon";
 import { describe, expect, it, afterEach, afterAll, beforeAll } from "vitest";
 import { MockTypeORM } from "../src";
 import { dataSource, Role } from "./utils/mock";
-import { getDefinedMethods } from "../src/helpers/general";
+import { retrieveAvailableMethods } from "../src/helpers/general";
 import { transaction } from "./utils/helpers";
 
 describe("General", () => {
@@ -75,7 +75,7 @@ describe("General", () => {
         property: 123,
       };
       const methods = ["method1", "method2", "method3"];
-      const result = getDefinedMethods(obj, methods);
+      const result = retrieveAvailableMethods(obj, methods);
       expect(result).toEqual(["method1", "method2"]);
     });
 
@@ -85,7 +85,7 @@ describe("General", () => {
         property2: "value",
       };
       const methods = ["method1", "method2"];
-      const result = getDefinedMethods(obj, methods);
+      const result = retrieveAvailableMethods(obj, methods);
       expect(result).toEqual([]);
     });
 
@@ -95,14 +95,14 @@ describe("General", () => {
         method2: () => {},
       };
       const methods = [];
-      const result = getDefinedMethods(obj, methods);
+      const result = retrieveAvailableMethods(obj, methods);
       expect(result).toEqual([]);
     });
 
     it("should handle objects with no properties gracefully", () => {
       const obj = {};
       const methods = ["method1", "method2"];
-      const result = getDefinedMethods(obj, methods);
+      const result = retrieveAvailableMethods(obj, methods);
       expect(result).toEqual([]);
     });
 
@@ -113,7 +113,7 @@ describe("General", () => {
         method3: () => {},
       };
       const methods = ["method1", "method2", "method3"];
-      const result = getDefinedMethods(obj, methods);
+      const result = retrieveAvailableMethods(obj, methods);
       expect(result).toEqual(["method1", "method2", "method3"]);
     });
   });

--- a/tests/repository.test.ts
+++ b/tests/repository.test.ts
@@ -20,7 +20,7 @@ describe("Repository", () => {
         const result = await roleRepository[method as any]();
 
         expect(result).toEqual(mockData);
-      }
+      },
     );
   });
 
@@ -43,6 +43,35 @@ describe("Repository", () => {
     const roleRepository = dataSource.getRepository(Role);
 
     await expect(roleRepository.find({})).rejects.toThrowError(/failed/i);
+  });
+
+  describe("create() without awaiting", () => {
+    it("should create a role with the correct data without awaiting", () => {
+      const typeorm = new MockTypeORM();
+      const mockRole = { name: "role", isAdmin: true };
+      typeorm.onMock(Role).toReturn(mockRole, "create");
+
+      const roleRepository = dataSource.getRepository(Role);
+      const role = roleRepository.create({ name: "role1" });
+
+      expect(role).toEqual(mockRole);
+    });
+
+    it("should create and save a role with the correct data", async () => {
+      const typeorm = new MockTypeORM();
+      const mockRole = { name: "role", isAdmin: true };
+      typeorm
+        .onMock(Role)
+        .toReturn(mockRole, "create")
+        .toReturn({ id: "1", ...mockRole }, "save");
+
+      const roleRepository = dataSource.getRepository(Role);
+      const role = roleRepository.create({ name: "role1" });
+      const savedRole = await roleRepository.save(role);
+
+      expect(role).toEqual(mockRole);
+      expect(savedRole).toEqual({ id: "1", ...mockRole });
+    });
   });
 
   describe("EntitySchema", () => {


### PR DESCRIPTION
Previously when users called the repository.create() function and checked the mock, our implementation was incorrectly returning a Promise while the original TypeORM function is synchronous. This fixes the mock to properly match TypeORM's behavior by returning the value directly without wrapping it in a Promise.