### PR TITLE
chore: add dependabot config to keep dependencies up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      eslint:
+        patterns:
+          - "eslint"
+          - "@eslint/*"
+          - "eslint-*"
+      typescript:
+        patterns:
+          - "typescript"
+          - "@typescript-eslint/*"
+          - "@types/*"
+      rollup:
+        patterns:
+          - "rollup"
+          - "@rollup/*"
+          - "rollup-*"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+      prettier:
+        patterns:
+          - "prettier"
+          - "eslint-config-prettier"
+          - "eslint-plugin-prettier"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This PR adds an dependabot config to keep dependencies up to date. The config includes a few groups to make sure there are no conflicts in the seperate PR's. Closes #21 